### PR TITLE
Added munin configuration settings to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,12 @@ When you want to change the default host (localhost) and port (5582) than you ca
     [prosody_*]
     env.host example.com
     env.port 5582
+
+
+If you want to get the number of registered users, add the following lines to **/etc/munin/plugin-conf.d/munin-node**:
+
+::
+
+    [prosody_users]
+    user prosody
+    group prosody


### PR DESCRIPTION
Munin configuration settings added for getting number of registered
users.
Without this settings you will get an access denied error when trying to
read the filesystem.
