### PR TITLE
Fix c2s:show() parser to work on 0.9 and 0.10

### DIFF
--- a/prosody_
+++ b/prosody_
@@ -148,7 +148,7 @@ def main():
             sys.exit(0)
 
         else:
-            client_presence_re = re.compile(r"- (.*?)\(\d+\)")
+            client_presence_re = re.compile(r"[]-] (.*?)\(\d+\)")
             telnet = telnetlib.Telnet(host, port)
             telnet.write("c2s:show()\n")
             telnet_response = telnet.read_until("clients", 5)


### PR DESCRIPTION
The c2s:show() format has changed on prosody 0.10, this patch should allow parsing both of them.
