### PR TITLE
Fix broken mem in prosody 0.10.2-1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ It is very simple to install the plugin.
 ::
 
     cd /usr/share/munin/plugins (or your munin plugins directory)
-    wget https://github.com/jarus/munin-prosody/raw/master/prosody_
+    wget https://github.com/jonnytischbein/munin-prosody/raw/master/prosody_
     chmod 755 prosody_
 
     ln -s /usr/share/munin/plugins/prosody_ /etc/munin/plugins/prosody_c2s
@@ -41,6 +41,8 @@ After the installation you need to restart your munin-node:
 ::
 
     /etc/init.d/munin-node restart
+
+Attention! You need to active the module admin_telnet in your prosody configuration and set the port 5582.
 
 
 Configuration
@@ -62,3 +64,8 @@ If you want to get the number of registered users, add the following lines to **
     [prosody_users]
     user prosody
     group prosody
+
+Update
+------------
+
+Nice the ouput in prosody version 0.10.2-1 seems to be changed the mem output is now fixed!

--- a/prosody_
+++ b/prosody_
@@ -61,10 +61,10 @@ def main():
             sys.exit(0)
 
         else:
-            memstats_re = re.compile(r"\|\s(\w+)\s+(\d+)\s+\|")
-            telnet = telnetlib.Telnet(host, port)
-            telnet.write(">for k,v in pairs(pposix.meminfo()) do print(k,v, '|') end\n")
-            mem_response = telnet.read_until("Result:", 5)
+            memstats_re = re.compile(r"\|\W+(\w+)\:\s\b(\d+\.\d+)\MB")
+	    telnet = telnetlib.Telnet(host, port)
+            telnet.write("server:memory()\n")
+	    mem_response = telnet.read_until("Result:", 5)
             telnet.write(">collectgarbage('count')*1024\n")
             telnet.write("quit\n")
             lua_response = telnet.read_all()
@@ -75,7 +75,7 @@ def main():
 
             lua_mem = re.compile("Result: (\d+)").findall(lua_response)[0]
 
-            print "memory_total.value", mem_map["allocated"]
+            print "memory_total.value", mem_map["Process"]
             print "memory_used.value", mem_map["used"]
             print "memory_lua.value", lua_mem
 


### PR DESCRIPTION
The prosody mem output seems to be changed or not working anymore. Fixed now.

Sampe Output:
> |                    ____                \   /     _   
>                    |  _ \ _ __ ___  ___  _-_   __| |_   _   
>                    | |_) | '__/ _ \/ __|/ _ \ / _` | | | | 
>                    |  __/| | | (_) \__ \ |_| | (_| | |_| |
 >                   |_|   |_|  \___/|___/\___/ \__,_|\__, |
 >                  A study in simplicity            |___/
>
> 
> | Welcome to the Prosody administration console. For a list of commands, type: help
> | You may find more help on using this console in our online documentation at  
> | http://prosody.im/doc/console
> 
> | Process: 46.30MB
> |    Used: 45.69MB (30.27MB by Lua)
> |    Free: 105.77KB (105.56KB returnable)
> | OK: OK 

Updatet mem telnet command to `server:memory()` and fixed broken reg match.
